### PR TITLE
clean-build

### DIFF
--- a/build/emdrv.rs
+++ b/build/emdrv.rs
@@ -17,8 +17,6 @@ fn main() {
         .init()
         .run();
 
-    let out_dir = env::var("OUT_DIR").unwrap();
-
     println!("The ARM embedded toolchain must be available in the PATH");
     env::set_var("CC", "arm-none-eabi-gcc");
     env::set_var("AR", "arm-none-eabi-ar");
@@ -29,10 +27,6 @@ fn main() {
     kit::kit_config(&mut config);
 
     config.compile("libemdrv.a");
-
-    println!("cargo:rustc-link-search=native={}", out_dir);
-    println!("cargo:rustc-link-lib=static=emdrv");
-
 }
 
 fn common_config(config: &mut Config) -> &mut Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![no_std]
-#![crate_type="lib"]
-#![crate_name="emdrv"]
 #![feature(asm, core, no_std)]
 
 #[macro_use]


### PR DESCRIPTION
gcc-rs already handles the linking. The crate-attributes are not really necessary
